### PR TITLE
Fix next review interval

### DIFF
--- a/script.js
+++ b/script.js
@@ -189,7 +189,7 @@ function updateProgressBar() {
 
 function calculateNextReviewDate(level) {
     let today = new Date();
-    today.setDate(today.getDate() + Math.pow(2, level - 1));
+    today.setDate(today.getDate() + Math.pow(2, level));
     return today.toISOString().split('T')[0];
 }
 


### PR DESCRIPTION
## Summary
- fix miscalculation of next review date which set new words to be reviewed on the same day

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6847e1d5329c832789d813f9b97daf41