### PR TITLE
Add activity panel to Review tab showing recent user actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,10 @@
                 <div id="progressText"></div>
                 <div id="progressFill"></div>
             </div>
+            <section id="activityPanel">
+                <h3>What you did</h3>
+                <ul id="activityList"></ul>
+            </section>
         </div>
 
         <div id="libraryTab" class="tab-content">

--- a/script.js
+++ b/script.js
@@ -27,6 +27,40 @@ let correctAnswersInSet = 0;
 let wrongAnswers = [];
 let currentSort = { column: null, direction: 'asc' };
 const WORDS_PER_SET = 10;
+const activityLog = [];
+const MAX_ACTIVITY_ITEMS = 8;
+
+function addActivityLog(message) {
+    const timestamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    activityLog.unshift({ message, timestamp });
+    if (activityLog.length > MAX_ACTIVITY_ITEMS) {
+        activityLog.pop();
+    }
+    renderActivityLog();
+}
+
+function renderActivityLog() {
+    const activityList = document.getElementById('activityList');
+    if (!activityList) {
+        return;
+    }
+
+    activityList.innerHTML = '';
+
+    if (activityLog.length === 0) {
+        const emptyItem = document.createElement('li');
+        emptyItem.className = 'activity-empty';
+        emptyItem.textContent = 'No activity yet.';
+        activityList.appendChild(emptyItem);
+        return;
+    }
+
+    activityLog.forEach((entry) => {
+        const item = document.createElement('li');
+        item.innerHTML = `<span class="activity-time">${entry.timestamp}</span> ${entry.message}`;
+        activityList.appendChild(item);
+    });
+}
 
 function openTab(tabName) {
     let tabContents = document.getElementsByClassName("tab-content");
@@ -46,6 +80,8 @@ function openTab(tabName) {
         updateReviewCount();
         displayReviewWord();
     }
+
+    addActivityLog(`Switched to ${tabName === 'reviewTab' ? 'Review' : 'Library'} tab.`);
 }
 
 function sortWords(column) {
@@ -59,6 +95,7 @@ function sortWords(column) {
     });
 
     updateLibraryTable();
+    addActivityLog(`Sorted by ${column} (${direction}).`);
 }
 
 function updateLibraryTable() {
@@ -71,7 +108,7 @@ function updateLibraryTable() {
         row.insertCell(2).textContent = word.level;
         row.insertCell(3).textContent = word.lastReview || 'Not reviewed';
         row.insertCell(4).textContent = word.nextReview || 'Review today';
-        
+
         let actionsCell = row.insertCell(5);
         let modifyBtn = document.createElement('button');
         modifyBtn.textContent = 'Modify';
@@ -94,21 +131,21 @@ function updateReviewCount() {
 function displayReviewWord() {
     const today = new Date().toISOString().split('T')[0];
     const reviewableWords = words.filter(word => !word.nextReview || word.nextReview <= today);
-    
+
     if (reviewableWords.length > 0) {
         if (currentSetIndex >= WORDS_PER_SET || currentSetIndex >= reviewableWords.length) {
             showSetResult();
             currentSetIndex = 0;
             correctAnswersInSet = 0;
         }
-        
+
         currentWordIndex = words.indexOf(reviewableWords[currentSetIndex]);
         document.getElementById("reviewWord").textContent = words[currentWordIndex].word;
         document.getElementById("answerInput").value = "";
         document.getElementById("result").textContent = "";
         document.getElementById("answerInput").disabled = false;
         document.getElementById("answerInput").focus();
-        
+
         updateProgressBar();
     } else {
         document.getElementById("reviewWord").textContent = "No words to review today";
@@ -122,32 +159,32 @@ function checkAnswer() {
     let correctAnswer = words[currentWordIndex].translation.toLowerCase();
     let lastResult = document.getElementById("lastResult");
     let result = document.getElementById("result");
-    
+
     if (userAnswer === correctAnswer) {
         result.textContent = "Correct!";
         result.className = "correct";
         document.getElementById('correctSound').play();
         words[currentWordIndex].level = Math.min(words[currentWordIndex].level + 1, 10);
         correctAnswersInSet++;
+        addActivityLog(`✅ ${words[currentWordIndex].word}: answered correctly.`);
     } else {
         result.textContent = "Incorrect. The correct answer is: " + correctAnswer;
         result.className = "incorrect";
         document.getElementById('wrongSound').play();
         words[currentWordIndex].level = 1;
+        addActivityLog(`❌ ${words[currentWordIndex].word}: answered "${userAnswer || 'empty'}".`);
     }
     if (userAnswer !== correctAnswer) {
         wrongAnswers.push({word: words[currentWordIndex].word, correct: correctAnswer, user: userAnswer});
     }
 
-
-    
     words[currentWordIndex].lastReview = new Date().toISOString().split('T')[0];
     words[currentWordIndex].nextReview = calculateNextReviewDate(words[currentWordIndex].level);
-    
-    lastResult.innerHTML = `Last word: ${words[currentWordIndex].word} - Your answer: ${userAnswer} - Correct answer: ${correctAnswer} 
+
+    lastResult.innerHTML = `Last word: ${words[currentWordIndex].word} - Your answer: ${userAnswer} - Correct answer: ${correctAnswer}
                             ${userAnswer === correctAnswer ? '✅' : '❌'}`;
     lastResult.className = userAnswer === correctAnswer ? "correct" : "incorrect";
-    
+
     currentSetIndex++;
     updateReviewCount();
     setTimeout(displayReviewWord, 1500);
@@ -176,6 +213,7 @@ function showSetResult() {
         wrongAnswersHtml += '</ul>';
         setResult.innerHTML += wrongAnswersHtml;
     }
+    addActivityLog(`Set finished with ${correctAnswersInSet}/${WORDS_PER_SET} correct answers.`);
     wrongAnswers = [];
 }
 
@@ -208,6 +246,7 @@ function addWord() {
         document.getElementById("newTranslation").value = "";
         updateLibraryTable();
         updateReviewCount();
+        addActivityLog(`Added new word: ${newWord} → ${newTranslation}.`);
     }
 }
 
@@ -216,20 +255,24 @@ function modifyWord(index) {
     let newWord = prompt("Enter new word:", word.word);
     let newTranslation = prompt("Enter new translation:", word.translation);
     if (newWord !== null && newTranslation !== null) {
+        const previousWord = word.word;
         words[index] = {
             ...word,
             word: newWord.trim(),
             translation: newTranslation.trim()
         };
         updateLibraryTable();
+        addActivityLog(`Modified "${previousWord}" to "${words[index].word}".`);
     }
 }
 
 function removeWord(index) {
     if (confirm("Are you sure you want to remove this word?")) {
+        const removedWord = words[index].word;
         words.splice(index, 1);
         updateLibraryTable();
         updateReviewCount();
+        addActivityLog(`Removed word: ${removedWord}.`);
     }
 }
 
@@ -256,3 +299,5 @@ document.getElementById('answerInput').addEventListener('keypress', function(e) 
 updateReviewCount();
 displayReviewWord();
 updateLibraryTable();
+renderActivityLog();
+addActivityLog('App loaded. Start reviewing or managing your library.');

--- a/styles.css
+++ b/styles.css
@@ -125,3 +125,34 @@ h1, h2 {
 .sort-arrow:hover {
     color: #4a90e2;
 }
+#activityPanel {
+    margin-top: 24px;
+    padding: 14px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background-color: #fafafa;
+}
+
+#activityPanel h3 {
+    margin: 0 0 10px;
+    font-size: 16px;
+}
+
+#activityList {
+    margin: 0;
+    padding-left: 20px;
+}
+
+#activityList li {
+    margin-bottom: 6px;
+}
+
+.activity-time {
+    color: #4a90e2;
+    font-weight: 600;
+}
+
+.activity-empty {
+    color: #888;
+    font-style: italic;
+}


### PR DESCRIPTION
### Motivation
- Improve UX by surfacing a short history of recent user actions in the Review tab so users can see what they did during a session. 
- Make it easier to debug and validate workflows (sorting, answering, adding/modifying/removing words) by recording events with timestamps. 
- Keep the history bounded to avoid unbounded memory growth by capping the list.

### Description
- Added an in‑app activity panel to the Review tab in `index.html` with `#activityPanel` and `#activityList` to show recent actions. 
- Implemented an in‑memory activity log in `script.js` (`activityLog`, `addActivityLog`, `renderActivityLog`) and a cap constant `MAX_ACTIVITY_ITEMS = 8`, and wired logging into `openTab`, `sortWords`, `checkAnswer`, `showSetResult`, `addWord`, `modifyWord`, and `removeWord` to record meaningful events. 
- Added styles for the activity panel and list in `styles.css` (`#activityPanel`, `#activityList`, `.activity-time`, `.activity-empty`) for readable presentation and an empty state. 
- Updated initialization to call `renderActivityLog()` and add a startup message; no AGENTS skills from `AGENTS.md` were used because this is a local UI enhancement.

### Testing
- Ran a static syntax check with `node --check script.js` which succeeded. 
- Launched a local server with `python3 -m http.server 4173` and executed an automated Playwright script to open the UI, perform a sample interaction and capture a screenshot, which completed successfully and produced a UI artifact (`artifacts/activity-log.png`). 
- Performed a smoke validation of the UI load and event wiring during the automated run and observed expected activity log entries (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992eaff37bc832782ab7832ab597ca3)